### PR TITLE
Fix movie ID misalignment between user-item matrix and model

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -17,10 +17,10 @@ app = FastAPI(title="Movie Recommender API")
 # Initialize data and model
 data_loader = MovieDataLoader("data/raw")
 movies_df, ratings_df = data_loader.load_data()
-user_item_matrix = data_loader.create_user_item_matrix()
+user_item_matrix, rated_movie_ids = data_loader.create_user_item_matrix()
 
 model = CollaborativeFilter()
-model.fit(user_item_matrix, movies_df['movieId'].tolist())
+model.fit(user_item_matrix, rated_movie_ids)
 
 class MovieRecommendation(BaseModel):
     """Pydantic model for movie recommendations."""

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -31,19 +31,24 @@ class MovieDataLoader:
         )
         return self.movies_df, self.ratings_df
     
-    def create_user_item_matrix(self) -> np.ndarray:
+    def create_user_item_matrix(self) -> Tuple[np.ndarray, List[int]]:
         """Create a user-item matrix for collaborative filtering.
         
+        Only movies that have at least one rating appear as columns, so the
+        movie IDs are returned alongside the matrix to keep them aligned.
+        Fitting a model with IDs from movies.csv instead would misattribute
+        similarity scores to the wrong movies.
+        
         Returns:
-            numpy array containing user-item ratings matrix
+            Tuple of (user-item ratings matrix, movie IDs aligned with its columns)
         """
         if self.ratings_df is None:
             raise ValueError("Ratings data not loaded. Call load_data() first.")
             
-        user_item_matrix = self.ratings_df.pivot(
+        rating_pivot = self.ratings_df.pivot(
             index='userId',
             columns='movieId',
             values='rating'
-        ).fillna(0).values
+        ).fillna(0)
         
-        return user_item_matrix
+        return rating_pivot.values, rating_pivot.columns.tolist()

--- a/test_recommender.py
+++ b/test_recommender.py
@@ -12,12 +12,12 @@ def main() -> None:
     print(movies_df.head())
 
     # Test user-item matrix creation
-    user_item_matrix = loader.create_user_item_matrix()
+    user_item_matrix, rated_movie_ids = loader.create_user_item_matrix()
     print('\nUser-item matrix shape:', user_item_matrix.shape)
 
     # Test model
     model = CollaborativeFilter()
-    model.fit(user_item_matrix, movies_df['movieId'].tolist())
+    model.fit(user_item_matrix, rated_movie_ids)
 
     # Get recommendations for a sample movie
     test_movie_id = movies_df['movieId'].iloc[0]


### PR DESCRIPTION
## Summary

- `create_user_item_matrix()` pivots ratings into 9,724 columns (only movies that have ratings, ordered by `movieId`), but the model was fit with all 9,742 IDs from `movies.csv`. The two orderings diverge from index 816 onward, so similarity scores were attributed to the wrong movies.
- The loader now returns the pivot's own column IDs alongside the matrix, and both `server.py` and `test_recommender.py` fit the model with those aligned IDs.

Closes #3

## Before / after

Recommendations for *Monty Python and the Holy Grail (1975)* (movie ID 1136, past the divergence point):

| Before (buggy) | After (fixed) |
|---|---|
| Last Klezmer: Leopold Kozlowski... (1.000) | Monty Python's Life of Brian (0.675) |
| Monty Python and the Holy Grail — itself (1.000) | The Princess Bride (0.631) |
| The Funeral (1.000) | Ferris Bueller's Day Off (0.600) |

*A recommender that confuses one movie for another has failed its empathy test.*

## Test plan

- [x] `python test_recommender.py` runs clean; matrix shape is (610, 9724) with aligned IDs
- [x] Before/after comparison script confirms sane recommendations past index 816
- [ ] Smoke-test `/recommendations/{movie_id}` endpoint in an env with fastapi installed